### PR TITLE
Enable Typesense embedding search

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,3 +49,36 @@ npm run docusaurus docs:version {version}
 ```bash
 npm run docusaurus gen-api-docs all
 ```
+
+## Typesense DocSearch with Embeddings
+
+DocSearch can generate vector embeddings for your documents and store them in
+Typesense. To enable this, update `docsearch.config.json` with a custom
+`field_definitions` section and add an `embedding` field. You also need to pass a
+`query_by` list including the `embedding` field through
+`typesenseSearchParameters` in `docusaurus.config.ts`.
+
+Example:
+
+```json
+"custom_settings": {
+  "field_definitions": [
+    {
+      "name": "embedding",
+      "type": "float[]",
+      "embed": {
+        "from": ["content"],
+        "model_config": {"model_name": "typesense/gte-small"}
+      }
+    }
+  ]
+}
+
+Using a built-in model such as `typesense/gte-small` does not require an API key.
+
+// docusaurus.config.ts
+typesenseSearchParameters: {
+  query_by: "hierarchy.lvl0,hierarchy.lvl1,hierarchy.lvl2,hierarchy.lvl3,hierarchy.lvl4,hierarchy.lvl5,hierarchy.lvl6,content,embedding",
+  prefix: false,
+}
+```

--- a/docsearch.config.json
+++ b/docsearch.config.json
@@ -18,6 +18,45 @@
   },
   "strip_chars": " .,;:#",
   "custom_settings": {
+    "field_definitions": [
+      {"name": "anchor", "type": "string", "optional": true},
+      {"name": "content", "type": "string", "optional": true},
+      {"name": "url", "type": "string", "facet": true},
+      {"name": "url_without_anchor", "type": "string", "facet": true, "optional": true},
+      {"name": "version", "type": "string[]", "facet": true, "optional": true},
+      {"name": "hierarchy.lvl0", "type": "string", "facet": true, "optional": true},
+      {"name": "hierarchy.lvl1", "type": "string", "facet": true, "optional": true},
+      {"name": "hierarchy.lvl2", "type": "string", "facet": true, "optional": true},
+      {"name": "hierarchy.lvl3", "type": "string", "facet": true, "optional": true},
+      {"name": "hierarchy.lvl4", "type": "string", "facet": true, "optional": true},
+      {"name": "hierarchy.lvl5", "type": "string", "facet": true, "optional": true},
+      {"name": "hierarchy.lvl6", "type": "string", "facet": true, "optional": true},
+      {"name": "type", "type": "string", "facet": true, "optional": true},
+      {"name": ".*_tag", "type": "string", "facet": true, "optional": true},
+      {"name": "language", "type": "string", "facet": true, "optional": true},
+      {"name": "tags", "type": "string[]", "facet": true, "optional": true},
+      {"name": "item_priority", "type": "int64"},
+      {
+        "name": "embedding",
+        "type": "float[]",
+        "embed": {
+          "from": [
+            "content",
+            "hierarchy.lvl0",
+            "hierarchy.lvl1",
+            "hierarchy.lvl2",
+            "hierarchy.lvl3",
+            "hierarchy.lvl4",
+            "hierarchy.lvl5",
+            "hierarchy.lvl6",
+            "tags"
+          ],
+          "model_config": {
+            "model_name": "typesense/gte-small"
+          }
+        }
+      }
+    ],
     "separatorsToIndex": "_",
     "attributesForFaceting": [
       "language",

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -150,7 +150,11 @@ const config: Config = {
       },
 
       // Optional: Typesense search parameters: https://typesense.org/docs/0.24.0/api/search.html#search-parameters
-      typesenseSearchParameters: {},
+      typesenseSearchParameters: {
+        query_by:
+          'hierarchy.lvl0,hierarchy.lvl1,hierarchy.lvl2,hierarchy.lvl3,hierarchy.lvl4,hierarchy.lvl5,hierarchy.lvl6,content,embedding',
+        prefix: false,
+      },
 
       // Optional
       contextualSearch: true,


### PR DESCRIPTION
## Summary
- add embedding field to `docsearch.config.json`
- configure Typesense search parameters to search the embedding field
- document how to enable embeddings
- use built-in `typesense/gte-small` embedding model instead of OpenAI

## Testing
- `npm run typecheck` *(fails: cannot find module '@docusaurus/plugin-content-docs/src/sidebars/types')*

------
https://chatgpt.com/codex/tasks/task_e_68492c3a6f74832c90f7bc8595b983f8