### PR TITLE
Update Typesense hybrid search parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ Using a built-in model such as `typesense/gte-small` does not require an API key
 // docusaurus.config.ts
 typesenseSearchParameters: {
   query_by: "hierarchy.lvl0,hierarchy.lvl1,hierarchy.lvl2,hierarchy.lvl3,hierarchy.lvl4,hierarchy.lvl5,hierarchy.lvl6,content,embedding",
-  prefix: false,
+  prefix: true,
+  sort_by: "_text_match:desc,_vector_distance:asc",
 }
 ```

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -153,7 +153,8 @@ const config: Config = {
       typesenseSearchParameters: {
         query_by:
           'hierarchy.lvl0,hierarchy.lvl1,hierarchy.lvl2,hierarchy.lvl3,hierarchy.lvl4,hierarchy.lvl5,hierarchy.lvl6,content,embedding',
-        prefix: false,
+        prefix: true,
+        sort_by: '_text_match:desc,_vector_distance:asc',
       },
 
       // Optional


### PR DESCRIPTION
## Summary
- tweak Typesense parameters to rank prefix matches before vector results
- document new search configuration

## Testing
- `npm run typecheck` *(fails: Cannot find module '@docusaurus/theme-common')*
- `npm run checkcmd` *(fails: docusaurus: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68498b0d6838832c8ab19793f6174f03