### PR TITLE
Add manual GitHub Pages deploy workflow

### DIFF
--- a/.github/workflows/manual-deploy.yml
+++ b/.github/workflows/manual-deploy.yml
@@ -1,0 +1,77 @@
+name: Manual Deploy at Commit
+
+on:
+  workflow_dispatch:
+    inputs:
+      commit_sha:
+        description: 'Commit SHA to deploy'
+        required: true
+        default: e8ddcca
+
+jobs:
+  build:
+    name: Build Docusaurus for commit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+          fetch-depth: 0
+          ref: ${{ inputs.commit_sha }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install dependencies
+        run: npm install --frozen-lockfile
+
+      - name: Check markdown file check
+        run: npx docusaurus-mdx-checker
+
+      - name: Generate sidebar for main branch
+        run: |
+          npm run generate-sidebar-adr-architecture
+          npm run generate-sidebar-userguide
+          npm run generate-sidebar-srs
+
+      - name: Build website
+        run: npm run build
+
+      - name: Upload Build Artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: build
+
+  deploy:
+    name: Deploy to GitHub Pages
+    needs: build
+
+    permissions:
+      pages: write
+      id-token: write
+
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4
+
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.commit_sha }}
+
+      - name: Run DocSearch Scraper
+        uses: celsiusnarhwal/typesense-scraper@v2
+        with:
+          api-key: ${{ secrets.TYPESENSE_API_KEY }}
+          host: ray5273.duckdns.org
+          port: 443
+          protocol: https
+          config: docsearch.config.json
+


### PR DESCRIPTION
## Summary
- allow manual deployment of GitHub Pages at any commit with a new `workflow_dispatch` workflow

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_684a15167168832cb510ab8753f0dd01